### PR TITLE
Adds feature for miscellaneous file deployment with extended regex

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -57,10 +57,10 @@
         <property name="textFileNamesRegex" default=".+\.(dat | param)" hidden="true" />
     </type-modification>
 
-    <type type="powercenter.DeployedPowercenterFile" extends="generic.CopiedArtifact"
-          deployable-type="powercenter.PowercenterFile" container-type="powercenter.PowercenterContainer"
-          description="Powercenter files.">
-        <generate-deployable type="powercenter.PowercenterFile" extends="generic.File" />
+    <type type="powercenter.DeployedPowercenterMiscFile" extends="generic.CopiedArtifact"
+          deployable-type="powercenter.PowercenterMiscFile" container-type="powercenter.PowercenterContainer"
+          description="Powercenter Miscellaneous files.">
+        <generate-deployable type="powercenter.PowercenterMiscFile" extends="generic.File" />
 
         <property name="functionality" kind="string" description="The value will determine in which subdirectory within the files directory the file will be copied."/>
 
@@ -71,9 +71,9 @@
         <property name="preserveExistingFiles" default="true" kind="boolean" hidden="false"/>
     </type>
 
-    <type-modification type="powercenter.PowercenterFile">
+    <type-modification type="powercenter.PowercenterMiscFile">
         <property name="scanPlaceholders" default="true" kind="boolean"/>
-        <property name="textFileNamesRegex" default=".+\.(dat | param | sh | ksh | txt)" hidden="false" />
+        <property name="textFileNamesRegex" default=".+\.(sh | ksh | txt | sql | ctl | properties | config | pl | env | dat)" hidden="false" description="A regex something like .+\.(sql | txt)"/>
     </type-modification>
 
 </synthetic>

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -21,6 +21,7 @@
         <property name="versioningEnabled" kind="boolean" default="false" description="If set to true, undeploy will not be executed, as pmrep deleteobject doesn't work with versioning enabled."/>
 
         <property name="paramFilesDirPath" kind="string" description="Param files directory."/>
+        <property name="filesDirPath" kind="string" description="Supplementary files directory."/>
 
         <method name="verifyConnection" label="Verify Connection" delegate="shellScript"
                 script="powercenter/powercenter_checkConnection"/>
@@ -48,11 +49,31 @@
         <property name="targetDirectoryShared" default="true" kind="boolean" hidden="true"/>
         <property name="targetDirectory" default="${deployed.container.paramFilesDirPath}/${deployed.functionality}/" hidden="true"/>
         <property name="targetFile" default="${deployed.name}" hidden="false"/>
+        <property name="preserveExistingFiles" default="true" kind="boolean" hidden="false"/>
     </type>
 
     <type-modification type="powercenter.PowercenterParamFile">
         <property name="scanPlaceholders" default="true" kind="boolean"/>
         <property name="textFileNamesRegex" default=".+\.(dat | param)" hidden="true" />
+    </type-modification>
+
+    <type type="powercenter.DeployedPowercenterFile" extends="generic.CopiedArtifact"
+          deployable-type="powercenter.PowercenterFile" container-type="powercenter.PowercenterContainer"
+          description="Powercenter files.">
+        <generate-deployable type="powercenter.PowercenterFile" extends="generic.File" />
+
+        <property name="functionality" kind="string" description="The value will determine in which subdirectory within the files directory the file will be copied."/>
+
+        <property name="createTargetDirectory" default="true" kind="boolean" hidden="true"/>
+        <property name="targetDirectoryShared" default="true" kind="boolean" hidden="true"/>
+        <property name="targetDirectory" default="${deployed.container.filesDirPath}/${deployed.functionality}/" hidden="true"/>
+        <property name="targetFile" default="${deployed.name}" hidden="false"/>
+        <property name="preserveExistingFiles" default="true" kind="boolean" hidden="false"/>
+    </type>
+
+    <type-modification type="powercenter.PowercenterFile">
+        <property name="scanPlaceholders" default="true" kind="boolean"/>
+        <property name="textFileNamesRegex" default=".+\.(dat | param | sh | ksh | txt)" hidden="false" />
     </type-modification>
 
 </synthetic>


### PR DESCRIPTION
Adds the property to not delete deployed artifacts from the containers by default. #12 
Creates a new sub-type: powercenter.DeployedPowercenterMiscFile, this will cover various other supplementary file types that are required to be deployed with the PowerCenter XML's (workflow objects)